### PR TITLE
chore: improve publish process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Unit Tests
+
 env:
   DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
   SUPERGOOD_CLIENT_ID: ${{ secrets.STAGING_SUPERGOOD_CLIENT_ID }}
@@ -11,6 +12,7 @@ on:
       - master
   pull_request:
     branches: [master]
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,13 +21,13 @@ jobs:
         node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+
       - name: Run Tests
         run: |
           yarn install
-          yarn clean
-          yarn build
           yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 supergood-*.log
-build/
+dist/
 .env

--- a/node.js.md
+++ b/node.js.md
@@ -1,4 +1,0 @@
-{
-  "message": "Bad credentials",
-  "documentation_url": "https://docs.github.com/rest"
-}

--- a/package.json
+++ b/package.json
@@ -1,19 +1,36 @@
 {
   "name": "supergood",
+  "version": "1.1.42",
+  "description": "",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "author": "Alex Klarfeld",
+  "license": "ISC",
   "repository": {
     "type": "git",
     "url": "git://github.com/supergoodsystems/supergood-js.git"
   },
-  "main": "build/src/index.js",
-  "types": "build/src/index.d.ts",
-  "version": "1.1.42",
+  "bugs": {
+    "url": "https://github.com/supergoodsystems/supergood-js/issues"
+  },
+  "homepage": "https://supergood.ai/",
+  "files": [
+    "/dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "scripts": {
+    "check:publish-ready": "yarn build && yarn test",
+    "preversion": "yarn check:publish-ready",
+    "postversion": "git add package.json && git commit -m \"chore: update $npm_package_name to v$npm_package_version\" && git tag $npm_package_name@$npm_package_version",
+    "prepublish": "yarn check:publish-ready",
+    "postpublish": "git push origin && git push origin --tags",
     "test": "NODE_ENV=test jest --setupFiles dotenv/config",
-    "clean": "rm -rf build/ && rm -rf supergood-*.log",
+    "clean": "rm -rf dist/ && rm -rf supergood-*.log",
     "build": "yarn run clean && tsc"
   },
-  "author": "Alex Klarfeld",
-  "license": "ISC",
   "dependencies": {
     "@mswjs/interceptors": "0.17.6",
     "lodash.get": "^4.4.2",
@@ -45,13 +62,5 @@
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.4",
     "undici": "^5.23.0"
-  },
-  "bugs": {
-    "url": "https://github.com/supergoodsystems/supergood-js/issues"
-  },
-  "homepage": "https://supergood.ai/",
-  "directories": {
-    "test": "test"
-  },
-  "description": ""
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,15 @@
   },
   "homepage": "https://supergood.ai/",
   "files": [
-    "/dist"
+    "src"
   ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
+  },
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6.0.0"
   },
   "scripts": {
     "check:publish-ready": "yarn build && yarn test",

--- a/publish.sh
+++ b/publish.sh
@@ -3,10 +3,6 @@ VERSION_TYPE=${1:-patch};
 curl -C - -0 https://raw.githubusercontent.com/supergoodsystems/docs/312ce3cd836606105def68ebe19d0b9cfc6c5452/integrate-with-clients/node.js/README.md > README.md;
 git add README.md;
 git commit -m "Update README.md";
-yarn run clean;
-npx tsc;
+
 npm version $VERSION_TYPE;
-npm publish --access public;
-git add .;
-git commit -m "Published latest version";
-git push origin master;
+npm publish;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "./build",
+    "outDir": "./dist",
     "allowJs": true,
     "removeComments": true,
     "target": "es2016",


### PR DESCRIPTION
- update GH test action
- add additional scripts for publishing
- update publish script
I have tested the package in simple express, fastify. nestjs apps. It works OK

In order to publish a new version run the commands:
```bash
npm version 1.43
npm publish
```