### PR TITLE
Fix interceptor memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Alex Klarfeld",
   "license": "ISC",
   "dependencies": {
-    "@mswjs/interceptors": "0.17.6",
+    "@supergood/interceptors": "git+https://github.com/supergoodsystems/interceptors.git",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "node-cache": "^5.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BatchInterceptor, IsomorphicRequest } from '@mswjs/interceptors';
+import { BatchInterceptor, IsomorphicRequest } from '@supergood/interceptors';
 import NodeCache from 'node-cache';
 import {
   getHeaderOptions,
@@ -10,7 +10,7 @@ import {
 } from './utils';
 import { postEvents } from './api';
 
-import nodeInterceptors from '@mswjs/interceptors/lib/presets/node';
+import nodeInterceptors from '@supergood/interceptors/lib/presets/node';
 
 import {
   HeaderOptionType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,63 +92,68 @@ const Supergood = () => {
     interceptor.apply();
     interceptor.on('request', async (request: IsomorphicRequest) => {
       const requestId = request.id;
-      try {
-        const url = new URL(request.url);
-        // Meant for debug and testing purposes
-        if (url.pathname === TestErrorPath) {
-          throw new Error(errors.TEST_ERROR);
-        }
-
-        const body = await request.clone().text();
-        const requestData = {
-          id: requestId,
-          headers: Object.fromEntries(request.headers.entries()),
-          method: request.method,
-          url: url.href,
-          path: url.pathname,
-          search: url.search,
-          body: safeParseJson(body),
-          requestedAt: new Date()
-        } as RequestType;
-
-        cacheRequest(requestData, baseUrl);
-      } catch (e) {
-        log.error(
-          errors.CACHING_REQUEST,
-          { request, config: supergoodConfig },
-          e as Error,
-          {
-            reportOut: !localOnly
+      const url = new URL(request.url);
+      if (shouldCachePayload(url.href, baseUrl, supergoodConfig)) {
+        try {
+          // Meant for debug and testing purposes
+          if (url.pathname === TestErrorPath) {
+            throw new Error(errors.TEST_ERROR);
           }
-        );
+
+          const body = await request.clone().text();
+          const requestData = {
+            id: requestId,
+            headers: Object.fromEntries(request.headers.entries()),
+            method: request.method,
+            url: url.href,
+            path: url.pathname,
+            search: url.search,
+            body: safeParseJson(body),
+            requestedAt: new Date()
+          } as RequestType;
+
+          cacheRequest(requestData);
+        } catch (e) {
+          log.error(
+            errors.CACHING_REQUEST,
+            { request, config: supergoodConfig },
+            e as Error,
+            {
+              reportOut: !localOnly
+            }
+          );
+        }
       }
     });
 
     interceptor.on('response', async (request, response) => {
       const requestId = request.id;
-      try {
-        const requestData = requestCache.get(requestId) as {
-          request: RequestType;
-        };
-        if (requestData) {
-          const responseData = {
-            response: {
-              headers: Object.fromEntries(response.headers.entries()),
-              status: response.status,
-              statusText: response.statusText,
-              body: response.body && safeParseJson(response.body),
-              respondedAt: new Date()
-            },
-            ...requestData
-          } as EventRequestType;
-          cacheResponse(responseData, baseUrl);
+      const url = new URL(request.url);
+      if (shouldCachePayload(url.href, baseUrl, supergoodConfig)) {
+        try {
+          const requestData = requestCache.get(requestId) as {
+            request: RequestType;
+          };
+          if (requestData) {
+            const responseData = {
+              response: {
+                headers: Object.fromEntries(response.headers.entries()),
+                status: response.status,
+                statusText: response.statusText,
+                body: response.body && safeParseJson(response.body),
+                respondedAt: new Date()
+              },
+              ...requestData
+            } as EventRequestType;
+            cacheResponse(responseData);
+          }
+        } catch (e) {
+          log.error(
+            errors.CACHING_RESPONSE,
+            { request, config: supergoodConfig },
+            e as Error
+          );
         }
-      } catch (e) {
-        log.error(
-          errors.CACHING_RESPONSE,
-          { request, config: supergoodConfig },
-          e as Error
-        );
       }
     });
 
@@ -157,25 +162,21 @@ const Supergood = () => {
     interval.unref();
   };
 
-  const cacheRequest = async (request: RequestType, baseUrl: string) => {
-    if (shouldCachePayload(request.url, baseUrl, supergoodConfig)) {
-      requestCache.set(request.id, { request });
-      log.debug('Setting Request Cache', {
-        request
-      });
-    }
+  const cacheRequest = async (request: RequestType) => {
+    requestCache.set(request.id, { request });
+    log.debug('Setting Request Cache', {
+      request
+    });
   };
 
-  const cacheResponse = async (event: EventRequestType, baseUrl: string) => {
-    if (shouldCachePayload(event.request.url, baseUrl, supergoodConfig)) {
-      responseCache.set(event.request.id, event);
-      log.debug('Setting Response Cache', {
-        id: event.request.id,
-        ...event
-      });
-      requestCache.del(event.request.id);
-      log.debug('Deleting Request Cache', { id: event.request.id });
-    }
+  const cacheResponse = async (event: EventRequestType) => {
+    responseCache.set(event.request.id, event);
+    log.debug('Setting Response Cache', {
+      id: event.request.id,
+      ...event
+    });
+    requestCache.del(event.request.id);
+    log.debug('Deleting Request Cache', { id: event.request.id });
   };
 
   // Force flush cache means don't wait for responses

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { InteractiveIsomorphicRequest } from '@mswjs/interceptors';
+import { InteractiveIsomorphicRequest } from '@supergood/interceptors';
 import { Response } from 'node-fetch';
 
 interface HeaderOptionType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,20 +605,6 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mswjs/interceptors@0.17.6":
-  version "0.17.6"
-  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.17.6.tgz#7f7900f4cd26f70d9f698685e4485b2f4101d26a"
-  integrity sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==
-  dependencies:
-    "@open-draft/until" "^1.0.3"
-    "@types/debug" "^4.1.7"
-    "@xmldom/xmldom" "^0.8.3"
-    debug "^4.3.3"
-    headers-polyfill "^3.1.0"
-    outvariant "^1.2.1"
-    strict-event-emitter "^0.2.4"
-    web-encoding "^1.1.5"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -673,6 +659,17 @@
   integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
   dependencies:
     "@sinonjs/commons" "^2.0.0"
+
+"@supergood/interceptors@git+https://github.com/supergoodsystems/interceptors.git":
+  version "0.17.6"
+  resolved "git+https://github.com/supergoodsystems/interceptors.git#8ea1938d1fe3c58ac5b9fc27742a1597510eb759"
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@xmldom/xmldom" "^0.8.3"
+    headers-polyfill "^3.1.0"
+    outvariant "^1.2.1"
+    strict-event-emitter "^0.2.4"
+    web-encoding "^1.1.5"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -733,13 +730,6 @@
   version "2.1.2"
   resolved "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz"
   integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
-
-"@types/debug@^4.1.7":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.9.tgz#906996938bc672aaf2fb8c0d3733ae1dda05b005"
-  integrity sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==
-  dependencies:
-    "@types/ms" "*"
 
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.31"
@@ -838,11 +828,6 @@
   version "3.0.1"
   resolved "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
-
-"@types/ms@*":
-  version "0.7.32"
-  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.32.tgz#f6cd08939ae3ad886fcc92ef7f0109dacddf61ab"
-  integrity sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==
 
 "@types/node-fetch@^2.6.4":
   version "2.6.6"
@@ -1330,13 +1315,22 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-call-bind@^1.0.0, call-bind@^1.0.2:
+call-bind@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+call-bind@^1.0.2, call-bind@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
+  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+  dependencies:
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.1"
+    set-function-length "^1.1.1"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -1578,7 +1572,7 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-debug@*, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@*, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1630,6 +1624,15 @@ defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+
+define-data-property@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
+  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+  dependencies:
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2202,6 +2205,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
@@ -2212,7 +2220,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.3:
+get-intrinsic@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
   integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
@@ -2221,6 +2229,16 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.3:
     has "^1.0.3"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
+
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
+  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+  dependencies:
+    function-bind "^1.1.2"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    hasown "^2.0.0"
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -2347,6 +2365,13 @@ has-flag@^4.0.0:
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
+  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+  dependencies:
+    get-intrinsic "^1.2.2"
+
 has-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
@@ -2375,6 +2400,13 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hasown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
 
 headers-polyfill@^3.1.0:
   version "3.3.0"
@@ -3982,6 +4014,16 @@ server-destroy@^1.0.1:
   resolved "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz"
   integrity sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==
 
+set-function-length@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.1.1.tgz#4bc39fafb0307224a33e106a7d35ca1218d659ed"
+  integrity sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
+  dependencies:
+    define-data-property "^1.1.1"
+    get-intrinsic "^1.2.1"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.0"
+
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
@@ -4398,12 +4440,12 @@ whatwg-url@^5.0.0:
     webidl-conversions "^3.0.0"
 
 which-typed-array@^1.1.11, which-typed-array@^1.1.2:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
-  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
+  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
   dependencies:
     available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
+    call-bind "^1.0.4"
     for-each "^0.3.3"
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"


### PR DESCRIPTION
We ran into an issue while dogfooding that the supergood library was utilizing a ton of memory and we traced it back to the @mswjs library logging every single event with `debug` and there being no way to disable it. I forked their repo and removed all their logging functionality. 

I hope in the future we can remove @msjw/interceptors completely, but for now, I want to see if this smaller fix helps reduce the memory consumption on our dogfooded instance of supergood.

Forked library here: https://github.com/supergoodsystems/interceptors.git

Pushed to `supergood@1.1.41-beta.1` for testing

- forked @mswjs/interceptors and removed all the logging functionality that was causing memory to blow up
- check if event should be cached way earlier in the logic