### PR TITLE
Add library info to supergood-bound headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
-  "version": "1.1.41",
+  "version": "1.1.42",
   "scripts": {
     "test": "NODE_ENV=test jest --setupFiles dotenv/config",
     "clean": "rm -rf build/ && rm -rf supergood-*.log",

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,6 @@ interface HeaderOptionType {
   headers: {
     'Content-Type': string;
     Authorization: string;
-    'supergood-api-type': string;
-    'supergood-api-version': string;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ interface HeaderOptionType {
   headers: {
     'Content-Type': string;
     Authorization: string;
+    'supergood-api-type': string;
+    'supergood-api-version': string;
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,9 @@ const getHeaderOptions = (
       'Content-Type': 'application/json',
       Authorization: `Basic ${Buffer.from(
         clientId + ':' + clientSecret
-      ).toString('base64')}`
+      ).toString('base64')}`,
+      'supergood-api-type': 'supergood-js',
+      'supergood-api-version': version
     }
   };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,7 @@ const getHeaderOptions = (
       'Content-Type': 'application/json',
       Authorization: `Basic ${Buffer.from(
         clientId + ':' + clientSecret
-      ).toString('base64')}`,
+      ).toString('base64')}`
     }
   };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,7 +184,7 @@ function post(
       'Content-Type': 'application/json',
       'Content-Length': dataString.length,
       Authorization: authorization,
-      'supergood-api-type': 'supergood-js',
+      'supergood-api': 'supergood-js',
       'supergood-api-version': packageVersion
     },
     timeout: 5000 // in ms

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,8 +80,6 @@ const getHeaderOptions = (
       Authorization: `Basic ${Buffer.from(
         clientId + ':' + clientSecret
       ).toString('base64')}`,
-      'supergood-api-type': 'supergood-js',
-      'supergood-api-version': version
     }
   };
 };
@@ -178,13 +176,16 @@ function post(
   authorization: string
 ): Promise<string> {
   const dataString = JSON.stringify(data);
+  const packageVersion = version;
 
   const options = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Content-Length': dataString.length,
-      Authorization: authorization
+      Authorization: authorization,
+      'supergood-api-type': 'supergood-js',
+      'supergood-api-version': packageVersion
     },
     timeout: 5000 // in ms
   };


### PR DESCRIPTION
This PR includes the library and library version in the header of requests being made to supergood. These are consumed on supergood's side and used for debugging.