### PR TITLE
Ignore internal URLs by default

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ const defaultConfig = {
   flushInterval: 1000,
   eventSinkEndpoint: '/events',
   errorSinkEndpoint: '/errors',
+  allowLocalUrls: false,
   keysToHash: [],
   ignoredDomains: [],
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import {
   logger,
   safeParseJson,
   prepareData,
-  shouldCachePayload,
   sleep
 } from './utils';
 import { postEvents } from './api';
@@ -78,7 +77,9 @@ const Supergood = () => {
       stdTTL: 0
     });
     interceptor = new NodeRequestInterceptor({
-      ignoredDomains: supergoodConfig.ignoredDomains
+      ignoredDomains: supergoodConfig.ignoredDomains,
+      allowLocalUrls: supergoodConfig.allowLocalUrls,
+      baseUrl
     });
 
     errorSinkUrl = `${baseUrl}${supergoodConfig.errorSinkEndpoint}`;
@@ -155,24 +156,20 @@ const Supergood = () => {
   };
 
   const cacheRequest = async (request: RequestType, baseUrl: string) => {
-    if (shouldCachePayload(request.url, baseUrl)) {
-      requestCache.set(request.id, { request });
-      log.debug('Setting Request Cache', {
-        request
-      });
-    }
+    requestCache.set(request.id, { request });
+    log.debug('Setting Request Cache', {
+      request
+    });
   };
 
   const cacheResponse = async (event: EventRequestType, baseUrl: string) => {
-    if (shouldCachePayload(event.request.url, baseUrl)) {
-      responseCache.set(event.request.id, event);
-      log.debug('Setting Response Cache', {
-        id: event.request.id,
-        ...event
-      });
-      requestCache.del(event.request.id);
-      log.debug('Deleting Request Cache', { id: event.request.id });
-    }
+    responseCache.set(event.request.id, event);
+    log.debug('Setting Response Cache', {
+      id: event.request.id,
+      ...event
+    });
+    requestCache.del(event.request.id);
+    log.debug('Deleting Request Cache', { id: event.request.id });
   };
 
   // Force flush cache means don't wait for responses

--- a/src/interceptor/NodeClientRequest.ts
+++ b/src/interceptor/NodeClientRequest.ts
@@ -14,10 +14,13 @@ import {
 } from './utils/getIncomingMessageBody';
 import { IsomorphicRequest } from './utils/IsomorphicRequest';
 import { getArrayBuffer } from './utils/bufferUtils';
+import { isAnIgnoredRequest } from './utils/isIgnoredRequest';
 
 export type NodeClientOptions = {
   emitter: EventEmitter;
   ignoredDomains?: string[];
+  allowLocalUrls: boolean;
+  baseUrl?: string;
 };
 
 export type Protocol = 'http' | 'https';
@@ -28,7 +31,7 @@ export class NodeClientRequest extends ClientRequest {
   public url: URL;
   public requestBuffer: Buffer | null;
   public requestId: string | null = null;
-  public ignoredDomains: string[];
+  public isAnIgnoredRequest: boolean;
 
   constructor(
     [url, requestOptions, callback]: NormalizedClientRequestArgs,
@@ -39,11 +42,17 @@ export class NodeClientRequest extends ClientRequest {
     this.requestId = crypto.randomUUID();
     this.url = url;
     this.emitter = options.emitter;
-    this.ignoredDomains = options.ignoredDomains ?? [];
 
     // Set request buffer to null by default so that GET/HEAD requests
     // without a body wouldn't suddenly get one.
     this.requestBuffer = null;
+
+    this.isAnIgnoredRequest = isAnIgnoredRequest({
+      url: this.url,
+      ignoredDomains: options.ignoredDomains ?? [],
+      baseUrl:  options.baseUrl ?? '',
+      allowLocalUrls: options.allowLocalUrls ?? false
+    });
   }
 
   private writeRequestBodyChunk(
@@ -82,7 +91,7 @@ export class NodeClientRequest extends ClientRequest {
     cb?: (() => void) | undefined
   ): this;
   end(chunk?: unknown, encoding?: unknown, cb?: unknown): this {
-    if (!this.ignoredDomains.includes(this.url.hostname)) {
+    if (!this.isAnIgnoredRequest) {
       const requestBody = getArrayBuffer(this.requestBuffer ?? Buffer.from([]));
       this.emitter.emit(
         'request',
@@ -120,7 +129,7 @@ export class NodeClientRequest extends ClientRequest {
         );
       }
 
-      if (!this.ignoredDomains.includes(this.url.hostname)) {
+      if (!this.isAnIgnoredRequest) {
         emitResponse(this.requestId as string, args[0], this.emitter);
       }
     }

--- a/src/interceptor/NodeRequestInterceptor.ts
+++ b/src/interceptor/NodeRequestInterceptor.ts
@@ -9,6 +9,8 @@ export type ClientRequestModules = Map<Protocol, typeof http | typeof https>;
 
 export interface NodeRequestInterceptorOptions {
   ignoredDomains?: string[];
+  allowLocalUrls?: boolean;
+  baseUrl?: string;
 }
 
 export class NodeRequestInterceptor {
@@ -38,7 +40,9 @@ export class NodeRequestInterceptor {
 
       const options = {
         emitter: this.emitter,
-        ignoredDomains: this.options.ignoredDomains
+        ignoredDomains: this.options.ignoredDomains,
+        allowLocalUrls: this.options.allowLocalUrls,
+        baseUrl: this.options.baseUrl,
       };
 
       // @ts-ignore

--- a/src/interceptor/utils/isIgnoredRequest.ts
+++ b/src/interceptor/utils/isIgnoredRequest.ts
@@ -1,0 +1,39 @@
+const commonLocalUrlTlds = [
+  'local'
+]
+
+export function isAnIgnoredRequest ({ url, ignoredDomains, baseUrl, allowLocalUrls }: {
+  url: URL, ignoredDomains: string[], baseUrl: string, allowLocalUrls: boolean
+}): boolean {
+
+  const { origin: baseOrigin } = new URL(baseUrl);
+  const hostname = url.hostname;
+
+  // Ignore intercepting responses to supergood
+  if(baseOrigin === url.origin) {
+    return true;
+  }
+
+  if(!hostname && !allowLocalUrls) {
+    return true;
+  }
+
+  const [, tld] = hostname.split('.')
+
+  // Ignore responses without a .com/.net/.org/etc
+  if(!tld && !allowLocalUrls) {
+    return true;
+  }
+
+  // Ignore responses with common TLD's
+  if(commonLocalUrlTlds.includes(tld) && !allowLocalUrls) {
+    return true;
+  }
+
+  // Ignore responses that have been explicitly excluded
+  if(ignoredDomains.includes(url.hostname)) {
+    return true
+  }
+
+  return false;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ interface ResponseType {
 interface ConfigType {
   flushInterval: number;
   ignoredDomains: string[];
+  allowLocalUrls: boolean;
   cacheTtl: number;
   keysToHash: string[];
   eventSinkEndpoint: string; // Defaults to {baseUrl}/events if not provided

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,18 +148,6 @@ const prepareData = (
   return events.filter((e) => hashValuesFromKeys(e, keysToHash));
 };
 
-const shouldCachePayload = (url: string, baseUrl: string) => {
-  const requestUrl = new URL(url);
-  const baseOriginUrl = new URL(baseUrl);
-
-  // Origin is needed for 'localhost' testing rather than hostname
-  if (requestUrl.origin == baseOriginUrl.origin) {
-    return false;
-  }
-
-  return true;
-};
-
 function post(
   url: string,
   data: Array<EventRequestType> | ErrorPayloadType,
@@ -226,7 +214,6 @@ export {
   logger,
   safeParseJson,
   prepareData,
-  shouldCachePayload,
   sleep,
   post
 };

--- a/test/e2e/axios.e2e.test.ts
+++ b/test/e2e/axios.e2e.test.ts
@@ -17,7 +17,10 @@ describe('axios library', () => {
     await Supergood.init(
       {
         clientId: SUPERGOOD_CLIENT_ID,
-        clientSecret: SUPERGOOD_CLIENT_SECRET
+        clientSecret: SUPERGOOD_CLIENT_SECRET,
+        config: {
+          allowLocalUrls: true
+        }
       },
       SUPERGOOD_SERVER
     );

--- a/test/e2e/core.e2e.test.ts
+++ b/test/e2e/core.e2e.test.ts
@@ -26,7 +26,7 @@ describe('core functionality', () => {
     test('captures all outgoing 200 http requests', async () => {
       await Supergood.init(
         {
-          config: SUPERGOOD_CONFIG,
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -63,7 +63,7 @@ describe('core functionality', () => {
       const httpErrorCodes = [400, 401, 403, 404, 500, 501, 502, 503, 504];
       await Supergood.init(
         {
-          config: SUPERGOOD_CONFIG,
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -91,7 +91,7 @@ describe('core functionality', () => {
     test('hanging response', async () => {
       await Supergood.init(
         {
-          config: SUPERGOOD_CONFIG,
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -114,7 +114,7 @@ describe('core functionality', () => {
       });
       await Supergood.init(
         {
-          config: SUPERGOOD_CONFIG,
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -133,7 +133,8 @@ describe('core functionality', () => {
       await Supergood.init(
         {
           config: {
-            keysToHash: ['response.body']
+            keysToHash: ['response.body'],
+            allowLocalUrls: true
           },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
@@ -153,7 +154,7 @@ describe('core functionality', () => {
     test('not hashing', async () => {
       await Supergood.init(
         {
-          config: { keysToHash: [] },
+          config: { keysToHash: [], allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -173,7 +174,8 @@ describe('core functionality', () => {
       await Supergood.init(
         {
           config: {
-            keysToHash: ['thisKeyDoesNotExist', 'response.thisKeyDoesNotExist']
+            keysToHash: ['thisKeyDoesNotExist', 'response.thisKeyDoesNotExist'],
+            allowLocalUrls: true
           },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
@@ -193,7 +195,7 @@ describe('core functionality', () => {
     test('ignores requests to ignored domains', async () => {
       await Supergood.init(
         {
-          config: { ignoredDomains: ['supergood-testbed.herokuapp.com'] },
+          config: { ignoredDomains: ['supergood-testbed.herokuapp.com'], allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -207,7 +209,7 @@ describe('core functionality', () => {
     test('operates normally when ignored domains is empty', async () => {
       await Supergood.init(
         {
-          config: { ignoredDomains: [] },
+          config: { ignoredDomains: [], allowLocalUrls: true },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
@@ -222,7 +224,8 @@ describe('core functionality', () => {
       await Supergood.init(
         {
           config: {
-            ignoredDomains: ['supergood-testbed.herokuapp.com']
+            ignoredDomains: ['supergood-testbed.herokuapp.com'],
+            allowLocalUrls: true
           },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
@@ -241,7 +244,10 @@ describe('core functionality', () => {
       await Supergood.init(
         {
           clientId: SUPERGOOD_CLIENT_ID,
-          clientSecret: SUPERGOOD_CLIENT_SECRET
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          config: {
+            allowLocalUrls: true
+          }
         },
         SUPERGOOD_SERVER
       );
@@ -264,7 +270,10 @@ describe('core functionality', () => {
       await Supergood.init(
         {
           clientId: SUPERGOOD_CLIENT_ID,
-          clientSecret: SUPERGOOD_CLIENT_SECRET
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          config: {
+            allowLocalUrls: true
+          }
         },
         SUPERGOOD_SERVER
       );
@@ -289,7 +298,8 @@ describe('core functionality', () => {
       await Supergood.init(
         {
           clientId: SUPERGOOD_CLIENT_ID,
-          clientSecret: SUPERGOOD_CLIENT_SECRET
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          config: { allowLocalUrls: true }
         },
         SUPERGOOD_SERVER
       );
@@ -307,7 +317,7 @@ describe('core functionality', () => {
     test('does not report out', async () => {
       await Supergood.init(
         {
-          config: SUPERGOOD_CONFIG,
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
           clientId: 'local-client-id',
           clientSecret: 'local-client-secret'
         },

--- a/test/e2e/node-fetch.e2e.test.ts
+++ b/test/e2e/node-fetch.e2e.test.ts
@@ -17,7 +17,8 @@ describe('node-fetch library', () => {
     await Supergood.init(
       {
         clientId: SUPERGOOD_CLIENT_ID,
-        clientSecret: SUPERGOOD_CLIENT_SECRET
+        clientSecret: SUPERGOOD_CLIENT_SECRET,
+        config: { allowLocalUrls: true }
       },
       SUPERGOOD_SERVER
     );

--- a/test/e2e/openai.e2e.test.ts
+++ b/test/e2e/openai.e2e.test.ts
@@ -18,7 +18,8 @@ describe.skip('openai library', () => {
     await Supergood.init(
       {
         clientId: SUPERGOOD_CLIENT_ID,
-        clientSecret: SUPERGOOD_CLIENT_SECRET
+        clientSecret: SUPERGOOD_CLIENT_SECRET,
+        config: { allowLocalUrls: true }
       },
       SUPERGOOD_SERVER
     );

--- a/test/e2e/superagent.e2e.test.ts
+++ b/test/e2e/superagent.e2e.test.ts
@@ -17,7 +17,8 @@ describe('superagent library', () => {
     await Supergood.init(
       {
         clientId: SUPERGOOD_CLIENT_ID,
-        clientSecret: SUPERGOOD_CLIENT_SECRET
+        clientSecret: SUPERGOOD_CLIENT_SECRET,
+        config: { allowLocalUrls: true }
       },
       SUPERGOOD_SERVER
     );

--- a/test/e2e/undici.e2e.test.ts
+++ b/test/e2e/undici.e2e.test.ts
@@ -18,7 +18,8 @@ describe.skip('undici library', () => {
     await Supergood.init(
       {
         clientId: SUPERGOOD_CLIENT_ID,
-        clientSecret: SUPERGOOD_CLIENT_SECRET
+        clientSecret: SUPERGOOD_CLIENT_SECRET,
+        config: { allowLocalUrls: true }
       },
       SUPERGOOD_SERVER
     );


### PR DESCRIPTION
Add functionality to ignore local URLs by default as well as ensure that all supergood logging calls are blocked.