### PR TITLE
Add partial match for ignored domains

### DIFF
--- a/src/interceptor/utils/isInterceptable.ts
+++ b/src/interceptor/utils/isInterceptable.ts
@@ -1,5 +1,9 @@
 const commonLocalUrlTlds = ['local'];
 
+const containsAnyPartial = (array, targetString) => {
+  return array.some(partial => targetString.includes(partial));
+};
+
 export function isInterceptable({
   url,
   ignoredDomains,
@@ -35,7 +39,7 @@ export function isInterceptable({
   }
 
   // Ignore requests that have been explicitly excluded
-  if (ignoredDomains.includes(url.hostname)) {
+  if (containsAnyPartial(ignoredDomains, url.hostname)) {
     return false;
   }
 

--- a/src/interceptor/utils/isInterceptable.ts
+++ b/src/interceptor/utils/isInterceptable.ts
@@ -1,6 +1,6 @@
 const commonLocalUrlTlds = ['local'];
 
-const containsAnyPartial = (array, targetString) => {
+const containsAnyPartial = (array: string[], targetString: string) => {
   return array.some(partial => targetString.includes(partial));
 };
 


### PR DESCRIPTION
We're running into an issue locally where the ignored domains are not being respected, specifically because we're setting something like

```
{
  ignoredDomains: ['datadoghq.com'],
}
```

but the actual hostname is:

`https://http-intake.logs.us3.datadoghq.com`

