### PR TITLE
Fix mangling responses

### DIFF
--- a/src/interceptor/utils/cloneIncomingMessage.ts
+++ b/src/interceptor/utils/cloneIncomingMessage.ts
@@ -1,0 +1,74 @@
+import { IncomingMessage } from 'http'
+import { PassThrough } from 'stream'
+
+export const IS_CLONE = Symbol('isClone')
+
+export interface ClonedIncomingMessage extends IncomingMessage {
+  [IS_CLONE]: boolean
+}
+
+/**
+ * Clones a given `http.IncomingMessage` instance.
+ */
+export function cloneIncomingMessage(
+  message: IncomingMessage
+): ClonedIncomingMessage {
+  const clone = message.pipe(new PassThrough())
+
+  // Inherit all direct "IncomingMessage" properties.
+  inheritProperties(message, clone)
+
+  // Deeply inherit the message prototypes (Readable, Stream, EventEmitter, etc.).
+  const clonedPrototype = Object.create(IncomingMessage.prototype)
+  getPrototypes(clone).forEach((prototype) => {
+    inheritProperties(prototype, clonedPrototype)
+  })
+  Object.setPrototypeOf(clone, clonedPrototype)
+
+  Object.defineProperty(clone, IS_CLONE, {
+    enumerable: true,
+    value: true,
+  })
+
+  return clone as unknown as ClonedIncomingMessage
+}
+
+/**
+ * Returns a list of all prototypes the given object extends.
+ */
+function getPrototypes(source: object): object[] {
+  const prototypes: object[] = []
+  let current = source
+
+  while ((current = Object.getPrototypeOf(current))) {
+    prototypes.push(current)
+  }
+
+  return prototypes
+}
+
+/**
+ * Inherits a given target object properties and symbols
+ * onto the given source object.
+ * @param source Object which should acquire properties.
+ * @param target Object to inherit the properties from.
+ */
+function inheritProperties(source: object, target: object): void {
+  const properties = [
+    ...Object.getOwnPropertyNames(source),
+    ...Object.getOwnPropertySymbols(source),
+  ]
+
+  for (const property of properties) {
+    if (target.hasOwnProperty(property)) {
+      continue
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(source, property)
+    if (!descriptor) {
+      continue
+    }
+
+    Object.defineProperty(target, property, descriptor)
+  }
+}


### PR DESCRIPTION
For some reason, the responses from the google auth API are getting mangled by the Supergood client. I think it has something to do with the responses getting written at the same time. This was causing our own login to fail when we were running the node client on our own instance.

I looked back at the original mswjs interceptor code and noticed that they were cloning the incoming messages so they didn't step on each other: 

https://github.com/mswjs/interceptors/blob/122a6533ce57d551dc3b59b3bb43a39026989b70/src/interceptors/ClientRequest/NodeClientRequest.ts#L368

I also noticed we were emitting the same response twice, as on line 125. We had been noticing duplicate events coming through our system and weren't exactly sure where they were coming from. This might be the culprit.

I'm not exactly sure why the responses are getting mangled by Supergood, but cloning them seems to have mitigated the problem.

When I say mangling responses, this is the response passed in when Supergood isn't enabled:

```
'{\n' +
    ' "issuer": "https://accounts.google.com",\n' +
    ' "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",\n' +
    ' "device_authorization_endpoint": "https://oauth2.googleapis.com/device/code",\n' +
    ' "token_endpoint": "https://oauth2.googleapis.com/token",\n' +
    ' "userinfo_endpoint": "https://openidconnect.googleapis.com/v1/userinfo",\n' +
    ' "revocation_endpoint": "https://oauth2.googleapis.com/revoke",\n' +
    ' "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",\n' +
    ' "response_types_supported": [\n' +
    '  "code",\n' +
    '  "token",\n' +
    '  "id_token",\n' +
    '  "code token",\n' +
    '  "code id_token",\n' +
    '  "token id_token",\n' +
    '  "code token id_token",\n' +
    '  "none"\n' +
    ' ],\n' +
    ' "subject_types_supported": [\n' +
    '  "public"\n' +
    ' ],\n' +
    ' "id_token_signing_alg_values_supported": [\n' +
    '  "RS256"\n' +
    ' ],\n' +
    ' "scopes_supported": [\n' +
    '  "openid",\n' +
    '  "email",\n' +
    '  "profile"\n' +
    ' ],\n' +
    ' "token_endpoint_auth_methods_supported": [\n' +
    '  "client_secret_post",\n' +
    '  "client_secret_basic"\n' +
    ' ],\n' +
    ' "claims_supported": [\n' +
    '  "aud",\n' +
    '  "email",\n' +
    '  "email_verified",\n' +
    '  "exp",\n' +
    '  "family_name",\n' +
    '  "given_name",\n' +
    '  "iat",\n' +
    '  "iss",\n' +
    '  "locale",\n' +
    '  "name",\n' +
    '  "picture",\n' +
    '  "sub"\n' +
    ' ],\n' +
    ' "code_challenge_methods_supported": [\n' +
    '  "plain",\n' +
    '  "S256"\n' +
    ' ],\n' +
    ' "grant_types_supported": [\n' +
    '  "authorization_code",\n' +
    '  "refresh_token",\n' +
    '  "urn:ietf:params:oauth:grant-type:device_code",\n' +
    '  "urn:ietf:params:oauth:grant-type:jwt-bearer"\n' +
    ' ]\n' +
    '}\n'
    ```
    
    and this is the mangled response passed back when supergood WAS enabled:
    
    ```
    'de token",\n' +
    '  "code id_token",\n' +
    '  "token id_token",\n' +
    '  "code token id_token",\n' +
    '  "none"\n' +
    ' ],\n' +
    ' "subject_types_supported": [\n' +
    '  "public"\n' +
    ' ],\n' +
    ' "id_token_signing_alg_values_supported": [\n' +
    '  "RS256"\n' +
    ' ],\n' +
    ' "scopes_supported": [\n' +
    '  "openid",\n' +
    '  "email",\n' +
    '  "profile"\n' +
    ' ],\n' +
    ' "token_endpoint_auth_methods_supported": [\n' +
    '  "client_secret_post",\n' +
    '  "client_secret_basic"\n' +
    ' ],\n' +
    ' "claims_supported": [\n' +
    '  "aud",\n' +
    '  "email",\n' +
    '  "email_verified",\n' +
    '  "exp",\n' +
    '  "family_name",\n' +
    '  "given_name",\n' +
    '  "iat",\n' +
    '  "iss",\n' +
    '  "locale",\n' +
    '  "name",\n' +
    '  "picture",\n' +
    '  "sub"\n' +
    ' ],\n' +
    ' "code_challenge_methods_supported": [\n' +
    '  "plain",\n' +
    '  "S256"\n' +
    ' ],\n' +
    ' "grant_types_supported": [\n' +
    '  "authorization_code",\n' +
    '  "refresh_token",\n' +
    '  "urn:ietf:params:oauth:grant-type:device_code",\n' +
    '  "urn:ietf:params:oauth:grant-type:jwt-bearer"\n' +
    ' ]\n' +
    '}\n'
    ```
    
    as you can see the string returned cuts off for some reason