### PR TITLE
Ignore ip address flag

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ const defaultConfig = {
   remoteConfigFetchEndpoint: '/config',
   telemetryEndpoint: '/telemetry',
   allowLocalUrls: false,
+  allowIpAddresses: false,
   logRequestHeaders: true,
   logRequestBody: true,
   logResponseHeaders: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ const Supergood = () => {
     const interceptorOpts = {
       ignoredDomains: supergoodConfig.ignoredDomains,
       allowLocalUrls: supergoodConfig.allowLocalUrls,
+      allowIpAddresses: supergoodConfig.allowIpAddresses,
       baseUrl
     };
 

--- a/src/interceptor/FetchInterceptor.ts
+++ b/src/interceptor/FetchInterceptor.ts
@@ -27,7 +27,8 @@ export class FetchInterceptor extends Interceptor {
         url: new URL(request.url),
         ignoredDomains: this.options.ignoredDomains ?? [],
         baseUrl: this.options.baseUrl ?? '',
-        allowLocalUrls: this.options.allowLocalUrls ?? false
+        allowLocalUrls: this.options.allowLocalUrls ?? false,
+        allowIpAddresses: this.options.allowIpAddresses ?? false,
       });
 
       if (_isInterceptable) {

--- a/src/interceptor/Interceptor.ts
+++ b/src/interceptor/Interceptor.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 export interface NodeRequestInterceptorOptions {
   ignoredDomains?: string[];
   allowLocalUrls?: boolean;
+  allowIpAddresses?: boolean;
   baseUrl?: string;
 }
 

--- a/src/interceptor/NodeClientRequest.ts
+++ b/src/interceptor/NodeClientRequest.ts
@@ -19,6 +19,7 @@ export type NodeClientOptions = {
   allowLocalUrls: boolean;
   baseUrl?: string;
   ignoredDomains?: string[];
+  allowIpAddresses: boolean;
 };
 
 export type Protocol = 'http' | 'https';
@@ -49,7 +50,8 @@ export class NodeClientRequest extends ClientRequest {
       url: this.url,
       ignoredDomains: options.ignoredDomains ?? [],
       baseUrl: options.baseUrl ?? '',
-      allowLocalUrls: options.allowLocalUrls ?? false
+      allowLocalUrls: options.allowLocalUrls ?? false,
+      allowIpAddresses: options.allowIpAddresses ?? false
     });
   }
 

--- a/src/interceptor/NodeRequestInterceptor.ts
+++ b/src/interceptor/NodeRequestInterceptor.ts
@@ -31,6 +31,7 @@ export class NodeRequestInterceptor extends Interceptor {
         emitter: this.emitter,
         ignoredDomains: this.options.ignoredDomains,
         allowLocalUrls: this.options.allowLocalUrls,
+        allowIpAddresses: this.options.allowIpAddresses,
         baseUrl: this.options.baseUrl
       };
 

--- a/src/interceptor/utils/isInterceptable.test.ts
+++ b/src/interceptor/utils/isInterceptable.test.ts
@@ -6,12 +6,14 @@ describe('isInterceptable', () => {
     const ignoredDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
+    const allowIpAddresses = false;
 
     const result = isInterceptable({
       url,
       ignoredDomains,
       baseUrl,
-      allowLocalUrls
+      allowLocalUrls,
+      allowIpAddresses,
     });
 
     expect(result).toBe(false);
@@ -22,12 +24,15 @@ describe('isInterceptable', () => {
     const ignoredDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
+    const allowIpAddresses = false;
+
 
     const result = isInterceptable({
       url,
       ignoredDomains,
       baseUrl,
-      allowLocalUrls
+      allowLocalUrls,
+      allowIpAddresses,
     });
 
     expect(result).toBe(false);
@@ -38,12 +43,14 @@ describe('isInterceptable', () => {
     const ignoredDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = true;
+    const allowIpAddresses = false;
 
     const result = isInterceptable({
       url,
       ignoredDomains,
       baseUrl,
-      allowLocalUrls
+      allowLocalUrls,
+      allowIpAddresses
     });
 
     expect(result).toBe(true);
@@ -54,12 +61,14 @@ describe('isInterceptable', () => {
     const ignoredDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
+    const allowIpAddresses = false;
 
     const result = isInterceptable({
       url,
       ignoredDomains,
       baseUrl,
-      allowLocalUrls
+      allowLocalUrls,
+      allowIpAddresses
     });
 
     expect(result).toBe(false);
@@ -70,12 +79,14 @@ describe('isInterceptable', () => {
     const ignoredDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = true;
+    const allowIpAddresses = false;
 
     const result = isInterceptable({
       url,
       ignoredDomains,
       baseUrl,
-      allowLocalUrls
+      allowLocalUrls,
+      allowIpAddresses
     });
 
     expect(result).toBe(true);
@@ -86,12 +97,14 @@ describe('isInterceptable', () => {
     const ignoredDomains: string[] = ['somedomain.com'];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
+    const allowIpAddresses = false;
 
     const result = isInterceptable({
       url,
       ignoredDomains,
       baseUrl,
-      allowLocalUrls
+      allowLocalUrls,
+      allowIpAddresses
     });
 
     expect(result).toBe(false);

--- a/src/interceptor/utils/isInterceptable.ts
+++ b/src/interceptor/utils/isInterceptable.ts
@@ -8,12 +8,14 @@ export function isInterceptable({
   url,
   ignoredDomains,
   baseUrl,
-  allowLocalUrls
+  allowLocalUrls,
+  allowIpAddresses
 }: {
   url: URL;
   ignoredDomains: string[];
   baseUrl: string;
   allowLocalUrls: boolean;
+  allowIpAddresses: boolean;
 }): boolean {
   const { origin: baseOrigin } = new URL(baseUrl);
   const hostname = url.hostname;
@@ -24,7 +26,11 @@ export function isInterceptable({
     return false;
   }
 
-  if (!hostname && !allowLocalUrls) {
+  if (!allowIpAddresses && /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)) {
+    return false;
+  }
+
+  if (!allowLocalUrls && !hostname) {
     return false;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ interface ConfigType {
   remoteConfigFetchInterval: number;
   ignoredDomains: string[];
   allowLocalUrls: boolean;
+  allowIpAddresses: boolean;
   cacheTtl: number;
   keysToHash: string[];
   remoteConfigFetchEndpoint: string; // Defaults to {baseUrl}/config if not provided

--- a/test/e2e/core.e2e.test.ts
+++ b/test/e2e/core.e2e.test.ts
@@ -119,67 +119,18 @@ describe('core functionality', () => {
   });
 
   xdescribe('config specifications', () => {
-    test('hashing', async () => {
+    it('should ignore requests to ip addresses if allowIpAddresses is false', async () => {
       await Supergood.init(
         {
-          config: {
-            keysToHash: ['response.body'],
-            allowLocalUrls: true
-          },
+          config: { ...SUPERGOOD_CONFIG, allowIpAddresses: false },
           clientId: SUPERGOOD_CLIENT_ID,
           clientSecret: SUPERGOOD_CLIENT_SECRET
         },
         SUPERGOOD_SERVER
       );
-      await axios.get(`${MOCK_DATA_SERVER}/posts`);
+      await axios.get('https://api.ipify.org?format=json');
       await Supergood.close();
-
-      checkPostedEvents(postEventsMock, 1, {
-        response: expect.objectContaining({
-          body: expect.arrayContaining([expect.stringMatching(BASE64_REGEX)])
-        })
-      });
-    });
-
-    it('should not hash anything', async () => {
-      await Supergood.init(
-        {
-          config: { keysToHash: [], allowLocalUrls: true },
-          clientId: SUPERGOOD_CLIENT_ID,
-          clientSecret: SUPERGOOD_CLIENT_SECRET
-        },
-        SUPERGOOD_SERVER
-      );
-      const response = await axios.get(`${MOCK_DATA_SERVER}/posts`);
-      await Supergood.close();
-
-      checkPostedEvents(postEventsMock, 1, {
-        response: expect.objectContaining({
-          body: response.data
-        })
-      });
-    });
-
-    it('should not hash if provided keys do not exist', async () => {
-      await Supergood.init(
-        {
-          config: {
-            keysToHash: ['thisKeyDoesNotExist', 'response.thisKeyDoesNotExist'],
-            allowLocalUrls: true
-          },
-          clientId: SUPERGOOD_CLIENT_ID,
-          clientSecret: SUPERGOOD_CLIENT_SECRET
-        },
-        SUPERGOOD_SERVER
-      );
-      const response = await axios.get(`${MOCK_DATA_SERVER}/posts`);
-      await Supergood.close();
-
-      checkPostedEvents(postEventsMock, 1, {
-        response: expect.objectContaining({
-          body: response.data
-        })
-      });
+      expect(postEventsMock).not.toHaveBeenCalled();
     });
 
     it('should ignore requests to ignored domains', async () => {
@@ -208,9 +159,9 @@ describe('core functionality', () => {
         },
         SUPERGOOD_SERVER
       );
-      await axios.get('https://supergood-testbed.herokuapp.com/200');
+      await axios.get('https://8.8.8.8/');
       await Supergood.close();
-      expect(postEventsMock).toHaveBeenCalled();
+      expect(postEventsMock).not.toHaveBeenCalled();
     }, 10000);
 
     it('should only post events for specified domains and ignore everything else', async () => {

--- a/test/e2e/core.e2e.test.ts
+++ b/test/e2e/core.e2e.test.ts
@@ -118,21 +118,7 @@ describe('core functionality', () => {
     });
   });
 
-  xdescribe('config specifications', () => {
-    it('should ignore requests to ip addresses if allowIpAddresses is false', async () => {
-      await Supergood.init(
-        {
-          config: { ...SUPERGOOD_CONFIG, allowIpAddresses: false },
-          clientId: SUPERGOOD_CLIENT_ID,
-          clientSecret: SUPERGOOD_CLIENT_SECRET
-        },
-        SUPERGOOD_SERVER
-      );
-      await axios.get('https://api.ipify.org?format=json');
-      await Supergood.close();
-      expect(postEventsMock).not.toHaveBeenCalled();
-    });
-
+  describe('config specifications', () => {
     it('should ignore requests to ignored domains', async () => {
       await Supergood.init(
         {
@@ -159,9 +145,37 @@ describe('core functionality', () => {
         },
         SUPERGOOD_SERVER
       );
-      await axios.get('https://8.8.8.8/');
+      await axios.get('https://supergood-testbed.herokuapp.com/200');
+      await Supergood.close();
+      expect(postEventsMock).toHaveBeenCalled();
+    }, 10000);
+
+    it('should ignore IP addresses by default', async () => {
+      await Supergood.init(
+        {
+          config: { ignoredDomains: [], allowLocalUrls: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET
+        },
+        SUPERGOOD_SERVER
+      );
+      const response = await fetch('http://13.107.4.52/');
       await Supergood.close();
       expect(postEventsMock).not.toHaveBeenCalled();
+    }, 10000);
+
+    it('should not ignore IP addresses if specified', async () => {
+      await Supergood.init(
+        {
+          config: { ignoredDomains: [], allowLocalUrls: true, allowIpAddresses: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET
+        },
+        SUPERGOOD_SERVER
+      );
+      const response = await fetch('http://13.107.4.52/');
+      await Supergood.close();
+      expect(postEventsMock).toHaveBeenCalled();
     }, 10000);
 
     it('should only post events for specified domains and ignore everything else', async () => {


### PR DESCRIPTION
Optionally allow or deny tracking calls to IP addresses. Typically these are just internal calls, but there are times when they might not be.