### PR TITLE
Add option to disable remote config

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ const defaultConfig = {
   errorSinkEndpoint: '/errors',
   remoteConfigFetchEndpoint: '/config',
   telemetryEndpoint: '/telemetry',
+  useRemoteConfig: true,
   allowLocalUrls: false,
   allowIpAddresses: false,
   logRequestHeaders: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,12 +227,19 @@ const Supergood = () => {
     };
 
     // Fetch the initial config and process it
-    await fetchAndProcessRemoteConfig();
+    if(supergoodConfig.useRemoteConfig) {
+      await fetchAndProcessRemoteConfig();
+    } else {
+      supergoodConfig.remoteConfig = supergoodConfig.remoteConfig ?? {};
+    }
+
     initializeInterceptors();
 
-    // Fetch the config ongoing every <remoteConfigFetchInterval> milliseconds
-    remoteConfigFetchInterval = setInterval(fetchAndProcessRemoteConfig, supergoodConfig.remoteConfigFetchInterval);
-    remoteConfigFetchInterval.unref();
+    if(supergoodConfig.useRemoteConfig) {
+      // Fetch the config ongoing every <remoteConfigFetchInterval> milliseconds
+      remoteConfigFetchInterval = setInterval(fetchAndProcessRemoteConfig, supergoodConfig.remoteConfigFetchInterval);
+      remoteConfigFetchInterval.unref();
+    }
 
     // Flushes the cache every <flushInterval> milliseconds
     flushInterval = setInterval(flushCache, supergoodConfig.flushInterval);

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ interface ConfigType {
   telemetryEndpoint: string; // Defaults to {baseUrl}/telemetry if not provided
   waitAfterClose: number;
   remoteConfig: RemoteConfigType;
+  useRemoteConfig: boolean;
   logRequestHeaders: boolean;
   logRequestBody: boolean;
   logResponseHeaders: boolean;


### PR DESCRIPTION
Allow users to toggle enabling the remote config fetch. This is especially helpful if running on serverless, to avoid an initial API call.

Users can manually set a remote config on initialization, which will get used.