### PR TITLE
Add allowed domains + New Telemetry Endpoint

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ const defaultConfig = {
   errorSinkEndpoint: '/errors',
   remoteConfigFetchEndpoint: '/config',
   telemetryEndpoint: '/telemetry',
+  baseTelemetryUrl: 'https://telemetry.supergood.ai',
   useRemoteConfig: true,
   allowLocalUrls: false,
   allowIpAddresses: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ const Supergood = () => {
       stdTTL: 0
     });
     const interceptorOpts = {
+      allowedDomains: supergoodConfig.allowedDomains,
       ignoredDomains: supergoodConfig.ignoredDomains,
       allowLocalUrls: supergoodConfig.allowLocalUrls,
       allowIpAddresses: supergoodConfig.allowIpAddresses,

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,10 +107,11 @@ const Supergood = () => {
         : [])
     ]);
 
-    errorSinkUrl = `${baseUrl}${supergoodConfig.errorSinkEndpoint}`;
     eventSinkUrl = `${baseUrl}${supergoodConfig.eventSinkEndpoint}`;
     remoteConfigFetchUrl = `${baseUrl}${supergoodConfig.remoteConfigFetchEndpoint}`;
-    telemetryUrl = `${baseUrl}${supergoodConfig.telemetryEndpoint}`;
+
+    telemetryUrl = `${supergoodConfig.baseTelemetryUrl}${supergoodConfig.telemetryEndpoint}`;
+    errorSinkUrl = `${supergoodConfig.baseTelemetryUrl}${supergoodConfig.errorSinkEndpoint}`;
 
     headerOptions = getHeaderOptions(clientId, clientSecret);
     log = logger({ errorSinkUrl, headerOptions });

--- a/src/interceptor/FetchInterceptor.ts
+++ b/src/interceptor/FetchInterceptor.ts
@@ -26,6 +26,7 @@ export class FetchInterceptor extends Interceptor {
       const _isInterceptable = isInterceptable({
         url: new URL(request.url),
         ignoredDomains: this.options.ignoredDomains ?? [],
+        allowedDomains: this.options.allowedDomains ?? [],
         baseUrl: this.options.baseUrl ?? '',
         allowLocalUrls: this.options.allowLocalUrls ?? false,
         allowIpAddresses: this.options.allowIpAddresses ?? false,

--- a/src/interceptor/Interceptor.ts
+++ b/src/interceptor/Interceptor.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 export interface NodeRequestInterceptorOptions {
   ignoredDomains?: string[];
+  allowedDomains?: string[];
   allowLocalUrls?: boolean;
   allowIpAddresses?: boolean;
   baseUrl?: string;

--- a/src/interceptor/NodeClientRequest.ts
+++ b/src/interceptor/NodeClientRequest.ts
@@ -19,6 +19,7 @@ export type NodeClientOptions = {
   allowLocalUrls: boolean;
   baseUrl?: string;
   ignoredDomains?: string[];
+  allowedDomains?: string[];
   allowIpAddresses: boolean;
 };
 
@@ -49,6 +50,7 @@ export class NodeClientRequest extends ClientRequest {
     this.isInterceptable = isInterceptable({
       url: this.url,
       ignoredDomains: options.ignoredDomains ?? [],
+      allowedDomains: options.allowedDomains ?? [],
       baseUrl: options.baseUrl ?? '',
       allowLocalUrls: options.allowLocalUrls ?? false,
       allowIpAddresses: options.allowIpAddresses ?? false

--- a/src/interceptor/utils/isInterceptable.test.ts
+++ b/src/interceptor/utils/isInterceptable.test.ts
@@ -4,6 +4,7 @@ describe('isInterceptable', () => {
   it('should return false if the request is same-origin', () => {
     const url = new URL('https://api.supergood.ai');
     const ignoredDomains: string[] = [];
+    const allowedDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
     const allowIpAddresses = false;
@@ -11,6 +12,7 @@ describe('isInterceptable', () => {
     const result = isInterceptable({
       url,
       ignoredDomains,
+      allowedDomains,
       baseUrl,
       allowLocalUrls,
       allowIpAddresses,
@@ -22,6 +24,7 @@ describe('isInterceptable', () => {
   it('should return false if the request without TLD', () => {
     const url = new URL('http://localhost');
     const ignoredDomains: string[] = [];
+    const allowedDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
     const allowIpAddresses = false;
@@ -30,6 +33,7 @@ describe('isInterceptable', () => {
     const result = isInterceptable({
       url,
       ignoredDomains,
+      allowedDomains,
       baseUrl,
       allowLocalUrls,
       allowIpAddresses,
@@ -41,6 +45,7 @@ describe('isInterceptable', () => {
   it('should return true if the request without TLD but allowLocalUrls is true', () => {
     const url = new URL('http://localhost');
     const ignoredDomains: string[] = [];
+    const allowedDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = true;
     const allowIpAddresses = false;
@@ -48,6 +53,7 @@ describe('isInterceptable', () => {
     const result = isInterceptable({
       url,
       ignoredDomains,
+      allowedDomains,
       baseUrl,
       allowLocalUrls,
       allowIpAddresses
@@ -59,6 +65,7 @@ describe('isInterceptable', () => {
   it('should return false if the request with common TLD', () => {
     const url = new URL('http://somedomain.local');
     const ignoredDomains: string[] = [];
+    const allowedDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
     const allowIpAddresses = false;
@@ -66,6 +73,7 @@ describe('isInterceptable', () => {
     const result = isInterceptable({
       url,
       ignoredDomains,
+      allowedDomains,
       baseUrl,
       allowLocalUrls,
       allowIpAddresses
@@ -77,6 +85,7 @@ describe('isInterceptable', () => {
   it('should return true if the request with common TLD but allowLocalUrls is true', () => {
     const url = new URL('http://somedomain.local');
     const ignoredDomains: string[] = [];
+    const allowedDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = true;
     const allowIpAddresses = false;
@@ -84,6 +93,7 @@ describe('isInterceptable', () => {
     const result = isInterceptable({
       url,
       ignoredDomains,
+      allowedDomains,
       baseUrl,
       allowLocalUrls,
       allowIpAddresses
@@ -95,6 +105,7 @@ describe('isInterceptable', () => {
   it('should return false if the request with ignored domain', () => {
     const url = new URL('http://somedomain.com');
     const ignoredDomains: string[] = ['somedomain.com'];
+    const allowedDomains: string[] = [];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
     const allowIpAddresses = false;
@@ -102,6 +113,7 @@ describe('isInterceptable', () => {
     const result = isInterceptable({
       url,
       ignoredDomains,
+      allowedDomains,
       baseUrl,
       allowLocalUrls,
       allowIpAddresses
@@ -109,4 +121,45 @@ describe('isInterceptable', () => {
 
     expect(result).toBe(false);
   });
+
+  it('should return false if allowedDomains is populated and the domain is not in the list', () => {
+    const url = new URL('http://somedomain.com');
+    const ignoredDomains: string[] = ['somedomain.com'];
+    const allowedDomains: string[] = [];
+    const baseUrl = 'https://api.supergood.ai';
+    const allowLocalUrls = false;
+    const allowIpAddresses = false;
+
+    const result = isInterceptable({
+      url,
+      ignoredDomains,
+      allowedDomains,
+      baseUrl,
+      allowLocalUrls,
+      allowIpAddresses
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if allowedDomains is populated and the domain is not in the list', () => {
+    const url = new URL('http://somedomain.com');
+    const ignoredDomains: string[] = ['somedomain.com'];
+    const allowedDomains: string[] = [];
+    const baseUrl = 'https://api.supergood.ai';
+    const allowLocalUrls = false;
+    const allowIpAddresses = false;
+
+    const result = isInterceptable({
+      url,
+      ignoredDomains,
+      allowedDomains,
+      baseUrl,
+      allowLocalUrls,
+      allowIpAddresses
+    });
+
+    expect(result).toBe(false);
+  });
+
 });

--- a/src/interceptor/utils/isInterceptable.test.ts
+++ b/src/interceptor/utils/isInterceptable.test.ts
@@ -122,7 +122,7 @@ describe('isInterceptable', () => {
     expect(result).toBe(false);
   });
 
-  it('should return true if allowedDomains is populated and the domain is not in the list', () => {
+  it('should return true if allowedDomains is populated and the domain is in the list', () => {
     const url = new URL('http://somedomain.com');
     const ignoredDomains: string[] = ['someotherdomain.com'];
     const allowedDomains: string[] = ['somedomain.com'];

--- a/src/interceptor/utils/isInterceptable.test.ts
+++ b/src/interceptor/utils/isInterceptable.test.ts
@@ -122,10 +122,30 @@ describe('isInterceptable', () => {
     expect(result).toBe(false);
   });
 
+  it('should return true if allowedDomains is populated and the domain is not in the list', () => {
+    const url = new URL('http://somedomain.com');
+    const ignoredDomains: string[] = ['someotherdomain.com'];
+    const allowedDomains: string[] = ['somedomain.com'];
+    const baseUrl = 'https://api.supergood.ai';
+    const allowLocalUrls = false;
+    const allowIpAddresses = false;
+
+    const result = isInterceptable({
+      url,
+      ignoredDomains,
+      allowedDomains,
+      baseUrl,
+      allowLocalUrls,
+      allowIpAddresses
+    });
+
+    expect(result).toBe(true);
+  });
+
   it('should return false if allowedDomains is populated and the domain is not in the list', () => {
     const url = new URL('http://somedomain.com');
     const ignoredDomains: string[] = ['somedomain.com'];
-    const allowedDomains: string[] = [];
+    const allowedDomains: string[] = ['someotherdomain.com'];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
     const allowIpAddresses = false;
@@ -142,10 +162,10 @@ describe('isInterceptable', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if allowedDomains is populated and the domain is not in the list', () => {
+  it('should return true if allowedDomains has a partial match for the domain', () => {
     const url = new URL('http://somedomain.com');
     const ignoredDomains: string[] = ['somedomain.com'];
-    const allowedDomains: string[] = [];
+    const allowedDomains: string[] = ['somedomain'];
     const baseUrl = 'https://api.supergood.ai';
     const allowLocalUrls = false;
     const allowIpAddresses = false;
@@ -159,7 +179,7 @@ describe('isInterceptable', () => {
       allowIpAddresses
     });
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
 });

--- a/src/interceptor/utils/isInterceptable.ts
+++ b/src/interceptor/utils/isInterceptable.ts
@@ -7,12 +7,14 @@ const containsAnyPartial = (array: string[], targetString: string) => {
 export function isInterceptable({
   url,
   ignoredDomains,
+  allowedDomains,
   baseUrl,
   allowLocalUrls,
   allowIpAddresses
 }: {
   url: URL;
   ignoredDomains: string[];
+  allowedDomains: string[];
   baseUrl: string;
   allowLocalUrls: boolean;
   allowIpAddresses: boolean;
@@ -20,6 +22,14 @@ export function isInterceptable({
   const { origin: baseOrigin } = new URL(baseUrl);
   const hostname = url.hostname;
   const [, tld] = hostname.split('.');
+
+  if(allowedDomains && allowedDomains.length > 0) {
+    if (containsAnyPartial(allowedDomains, hostname)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 
   // Don't intercept internal requests
   if (baseOrigin === url.origin) {
@@ -45,7 +55,7 @@ export function isInterceptable({
   }
 
   // Ignore requests that have been explicitly excluded
-  if (containsAnyPartial(ignoredDomains, url.hostname)) {
+  if (containsAnyPartial(ignoredDomains, hostname)) {
     return false;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ interface ConfigType {
   eventSinkEndpoint: string; // Defaults to {baseUrl}/events if not provided
   errorSinkEndpoint: string; // Defaults to {baseUrl}/errors if not provided
   telemetryEndpoint: string; // Defaults to {baseUrl}/telemetry if not provided
+  baseTelemetryUrl: string; // Defaults to https://telemetry.supergood.ai if not provided
   waitAfterClose: number;
   remoteConfig: RemoteConfigType;
   useRemoteConfig: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ interface ConfigType {
   flushInterval: number;
   remoteConfigFetchInterval: number;
   ignoredDomains: string[];
+  allowedDomains: string[];
   allowLocalUrls: boolean;
   allowIpAddresses: boolean;
   cacheTtl: number;


### PR DESCRIPTION
Adding allowed domains back in, currently we only support ignoredDomains.

AllowedDomains overrides any other configuration, if it's populated.