### PR TITLE
emit why telemetry post failed locally

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -15,6 +15,7 @@ const postError = async (
     return response;
   } catch (e) {
     console.warn(`Failed to report error to ${errorSinkUrl}`);
+    console.warn(JSON.stringify(e, ['stack', 'message']))
     return null;
   }
 };


### PR DESCRIPTION
While trying to debug our own staging instance running supergood, it seems like this log line continually gets printed but I can't tie it to another reported error. I'd have to shell in and debug step through to find the offending error. Instead, warning in the same logging context about the error should suffice for debugging purposes.