### PR TITLE
Return `void` instead of `Promise<void>` if `useRemoteConfig: false`

### DIFF
--- a/test/e2e/core.e2e.test.ts
+++ b/test/e2e/core.e2e.test.ts
@@ -201,6 +201,37 @@ describe('core functionality', () => {
         })
       });
     }, 10000);
+
+    it('should return a promise when run without useRemoteConfig: false', async () => {
+      const ret = Supergood.init(
+        {
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET
+        },
+        SUPERGOOD_SERVER
+      );
+      expect(ret).toHaveProperty('then');
+      await Supergood.close();
+    });
+
+    it('should return void when run with useRemoteConfig: false', async () => {
+      const ret = Supergood.init(
+        {
+          config: {
+            ...SUPERGOOD_CONFIG,
+            allowLocalUrls: true,
+            useRemoteConfig: false
+          },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET
+        },
+        SUPERGOOD_SERVER
+      );
+      
+      expect(ret).toBe(undefined);
+      await Supergood.close();
+    });
   });
 
   describe('encoding', () => {


### PR DESCRIPTION
_Hide whitespace changes when reviewing_

A slightly zany solution, but this allows us to:
- Make `no-floating-promises` happy without silencing with `void` when `useRemoteConfig: false`
- Preserve linter safety and also avoiding startup race conditions if we **aren't** running with `useRemoteConfig: false`

```typescript
Supergood.init({ config: { useRemoteConfig: false } }); // void
Supergood.init({ config: { useRemoteConfig: true } }); // Promise<void>
Supergood.init({ }); // Promise<void>
```