### PR TITLE
Add explicit logging functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -455,9 +455,7 @@ const Supergood = () => {
         tags,
         isWithinContext: () => supergoodAsyncLocalStorage.getStore()?.instanceId === instanceId
       }, baseUrl, baseTelemetryUrl);
-      const result = await fn();
-      await close();
-      return result;
+      return fn();
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,7 +443,7 @@ const Supergood = () => {
     baseTelemetryUrl?: string;
   }, fn: () => Promise<TRet>): Promise<TRet> => {
     const instanceId = crypto.randomUUID();
-    return supergoodAsyncLocalStorage.run({ instanceId }, async () => {
+    return supergoodAsyncLocalStorage.run({ tags, instanceId }, async () => {
       await init({
         clientId,
         clientSecret,
@@ -473,7 +473,7 @@ const Supergood = () => {
     baseTelemetryUrl?: string;
   }) => {
     const instanceId = crypto.randomUUID();
-    supergoodAsyncLocalStorage.enterWith({ instanceId });
+    supergoodAsyncLocalStorage.enterWith({ instanceId, tags });
     await init({
       clientId,
       clientSecret,
@@ -484,8 +484,8 @@ const Supergood = () => {
   }
 
   const stopCapture = async () => {
-    supergoodAsyncLocalStorage.disable();
     await close();
+    supergoodAsyncLocalStorage.disable();
   }
 
   // Set up cleanup catch for exit signals

--- a/src/index.ts
+++ b/src/index.ts
@@ -488,9 +488,22 @@ const Supergood = () => {
     supergoodAsyncLocalStorage.disable();
   }
 
+  const getAsyncLocalStorage = () => supergoodAsyncLocalStorage.getStore();
+
   // Set up cleanup catch for exit signals
   onExit(() => close(), { alwaysLast: true });
-  return { close, flushCache, waitAndFlushCache, withTags, init, withCapture, startCapture, stopCapture };
+
+  return {
+    close,
+    flushCache,
+    waitAndFlushCache,
+    withTags,
+    init,
+    withCapture,
+    startCapture,
+    stopCapture,
+    getAsyncLocalStorage
+  };
 };
 
 export = Supergood();

--- a/src/interceptor/BatchInterceptor.ts
+++ b/src/interceptor/BatchInterceptor.ts
@@ -12,9 +12,9 @@ export class BatchInterceptor {
     this.interceptors = interceptors;
   }
 
-  public setup() {
+  public setup({ isWithinContext }: { isWithinContext: () => boolean }) {
     for (const interceptor of this.interceptors) {
-      interceptor.setup();
+      interceptor.setup({ isWithinContext });
 
       this.subscriptions.push(() => interceptor.teardown());
     }

--- a/src/interceptor/FetchInterceptor.ts
+++ b/src/interceptor/FetchInterceptor.ts
@@ -17,7 +17,7 @@ export class FetchInterceptor extends Interceptor {
     );
   }
 
-  public setup() {
+  public setup({ isWithinContext }: { isWithinContext: () => boolean }){
     const pureFetch = globalThis.fetch;
 
     globalThis.fetch = async (input, init) => {
@@ -30,6 +30,7 @@ export class FetchInterceptor extends Interceptor {
         baseUrl: this.options.baseUrl ?? '',
         allowLocalUrls: this.options.allowLocalUrls ?? false,
         allowIpAddresses: this.options.allowIpAddresses ?? false,
+        isWithinContext: isWithinContext ?? (() => true),
       });
 
       if (_isInterceptable) {

--- a/src/interceptor/Interceptor.ts
+++ b/src/interceptor/Interceptor.ts
@@ -18,7 +18,7 @@ export class Interceptor {
     this.options = options ?? {};
   }
 
-  public setup(): void {
+  public setup({ isWithinContext }: { isWithinContext: () => boolean }): void {
     throw new Error('Not implemented');
   }
 

--- a/src/interceptor/NodeClientRequest.ts
+++ b/src/interceptor/NodeClientRequest.ts
@@ -16,11 +16,12 @@ import { cloneIncomingMessage } from './utils/cloneIncomingMessage';
 
 export type NodeClientOptions = {
   emitter: EventEmitter;
-  allowLocalUrls: boolean;
+  allowLocalUrls?: boolean;
   baseUrl?: string;
   ignoredDomains?: string[];
   allowedDomains?: string[];
-  allowIpAddresses: boolean;
+  allowIpAddresses?: boolean;
+  isWithinContext?: () => boolean;
 };
 
 export type Protocol = 'http' | 'https';
@@ -53,7 +54,8 @@ export class NodeClientRequest extends ClientRequest {
       allowedDomains: options.allowedDomains ?? [],
       baseUrl: options.baseUrl ?? '',
       allowLocalUrls: options.allowLocalUrls ?? false,
-      allowIpAddresses: options.allowIpAddresses ?? false
+      allowIpAddresses: options.allowIpAddresses ?? false,
+      isWithinContext: options.isWithinContext ?? (() => true)
     });
   }
 

--- a/src/interceptor/NodeRequestInterceptor.ts
+++ b/src/interceptor/NodeRequestInterceptor.ts
@@ -4,6 +4,10 @@ import { request } from './http.request';
 import { get } from './http.get';
 import { Protocol } from './NodeClientRequest';
 import { Interceptor, NodeRequestInterceptorOptions } from './Interceptor';
+import {
+  ClientRequestArgs,
+  normalizeClientRequestArgs,
+} from './utils/request-args'
 
 export type ClientRequestModules = Map<Protocol, typeof http | typeof https>;
 
@@ -18,7 +22,7 @@ export class NodeRequestInterceptor extends Interceptor {
     this.modules.set('https', https);
   }
 
-  public setup() {
+  public setup({ isWithinContext }: { isWithinContext: () => boolean }) {
     for (const [protocol, requestModule] of this.modules) {
       const { request: pureRequest, get: pureGet } = requestModule;
 
@@ -30,9 +34,11 @@ export class NodeRequestInterceptor extends Interceptor {
       const options = {
         emitter: this.emitter,
         ignoredDomains: this.options.ignoredDomains,
+        allowedDomains: this.options.allowedDomains,
         allowLocalUrls: this.options.allowLocalUrls,
         allowIpAddresses: this.options.allowIpAddresses,
-        baseUrl: this.options.baseUrl
+        baseUrl: this.options.baseUrl,
+        isWithinContext,
       };
 
       // @ts-ignore
@@ -40,6 +46,7 @@ export class NodeRequestInterceptor extends Interceptor {
 
       // @ts-ignore
       requestModule.get = get(protocol, options);
+
     }
   }
 }

--- a/src/interceptor/http.get.ts
+++ b/src/interceptor/http.get.ts
@@ -1,4 +1,7 @@
 import { ClientRequest } from 'node:http'
+import http from 'http';
+import https from 'https';
+
 import {
   NodeClientOptions,
   NodeClientRequest,

--- a/src/interceptor/utils/isInterceptable.test.ts
+++ b/src/interceptor/utils/isInterceptable.test.ts
@@ -1,5 +1,7 @@
 import { isInterceptable } from './isInterceptable';
 
+const isWithinContext = () => true;
+
 describe('isInterceptable', () => {
   it('should return false if the request is same-origin', () => {
     const url = new URL('https://api.supergood.ai');
@@ -16,6 +18,7 @@ describe('isInterceptable', () => {
       baseUrl,
       allowLocalUrls,
       allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(false);
@@ -37,6 +40,7 @@ describe('isInterceptable', () => {
       baseUrl,
       allowLocalUrls,
       allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(false);
@@ -56,7 +60,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(true);
@@ -76,7 +81,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(false);
@@ -96,7 +102,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(true);
@@ -116,7 +123,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(false);
@@ -136,7 +144,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(true);
@@ -156,7 +165,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(false);
@@ -176,7 +186,8 @@ describe('isInterceptable', () => {
       allowedDomains,
       baseUrl,
       allowLocalUrls,
-      allowIpAddresses
+      allowIpAddresses,
+      isWithinContext
     });
 
     expect(result).toBe(true);

--- a/src/interceptor/utils/isInterceptable.ts
+++ b/src/interceptor/utils/isInterceptable.ts
@@ -10,7 +10,8 @@ export function isInterceptable({
   allowedDomains,
   baseUrl,
   allowLocalUrls,
-  allowIpAddresses
+  allowIpAddresses,
+  isWithinContext: isWithinContext = () => true,
 }: {
   url: URL;
   ignoredDomains: string[];
@@ -18,7 +19,13 @@ export function isInterceptable({
   baseUrl: string;
   allowLocalUrls: boolean;
   allowIpAddresses: boolean;
+  isWithinContext: () => boolean;
 }): boolean {
+
+  if (!isWithinContext()) {
+    return false;
+  }
+
   const { origin: baseOrigin } = new URL(baseUrl);
   const hostname = url.hostname;
   const [, tld] = hostname.split('.');

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,7 @@ interface EventRequestType {
 
 type SupergoodContext = {
   instanceId?: string;
-  tags: TagType;
+  tags?: TagType;
 };
 
 // interface EventResponseType {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ interface ConfigType {
   logRequestBody: boolean;
   logResponseHeaders: boolean;
   logResponseBody: boolean;
+  isWithinContext?: () => boolean;
 }
 
 interface TelemetryType {
@@ -97,7 +98,8 @@ interface EventRequestType {
 }
 
 type SupergoodContext = {
-  tags: Record<string, string | number | string[]>;
+  tags?: Record<string, string | number | string[]>;
+  instanceId?: string;
 };
 
 // interface EventResponseType {}

--- a/test/e2e/core.e2e.test.ts
+++ b/test/e2e/core.e2e.test.ts
@@ -228,7 +228,7 @@ describe('core functionality', () => {
         },
         SUPERGOOD_SERVER
       );
-      
+
       expect(ret).toBe(undefined);
       await Supergood.close();
     });

--- a/test/e2e/explicit-capture.e2e.test.ts
+++ b/test/e2e/explicit-capture.e2e.test.ts
@@ -52,6 +52,7 @@ describe('capture functionality', () => {
       const getInterval = setInterval(async () => {
         await axios.get(`${MOCK_DATA_SERVER}/posts`), 250
       });
+      getInterval.unref();
 
       await Supergood.withCapture(
         {
@@ -66,7 +67,7 @@ describe('capture functionality', () => {
         }
       })
 
-      getInterval.unref();
+      clearInterval(getInterval);
 
       checkPostedEvents(postEventsMock, numberOfHttpCalls, {
         request: expect.objectContaining({
@@ -97,6 +98,7 @@ describe('capture functionality', () => {
       }
 
       await Supergood.stopCapture();
+
       await axios.get(`${MOCK_DATA_SERVER}/posts`);
 
       checkPostedEvents(postEventsMock, numberOfHttpCalls, {
@@ -115,6 +117,7 @@ describe('capture functionality', () => {
       const getInterval = setInterval(async () => {
         await axios.get(`${MOCK_DATA_SERVER}/posts`), 250
       });
+      getInterval.unref();
 
       await Supergood.startCapture(
         {
@@ -131,7 +134,7 @@ describe('capture functionality', () => {
 
       await Supergood.stopCapture();
 
-      getInterval.unref();
+      clearInterval(getInterval);
 
       checkPostedEvents(postEventsMock, numberOfHttpCalls, {
         request: expect.objectContaining({

--- a/test/e2e/explicit-capture.e2e.test.ts
+++ b/test/e2e/explicit-capture.e2e.test.ts
@@ -30,6 +30,7 @@ describe('capture functionality', () => {
           await axios.get(`${MOCK_DATA_SERVER}/posts`);
         }
       })
+      await Supergood.close();
       await axios.get(`${MOCK_DATA_SERVER}/posts`);
       checkPostedEvents(postEventsMock, numberOfHttpCalls, {
         request: expect.objectContaining({
@@ -61,6 +62,7 @@ describe('capture functionality', () => {
           await axios.get(`${MOCK_DATA_SERVER}/posts`);
         }
       })
+      await Supergood.close();
 
       clearInterval(getInterval);
 
@@ -113,6 +115,7 @@ describe('capture functionality', () => {
       const getInterval = setInterval(async () => {
         await axios.get(`${MOCK_DATA_SERVER}/posts`), 250
       });
+
       getInterval.unref();
       await Supergood.startCapture(
         {

--- a/test/e2e/explicit-capture.e2e.test.ts
+++ b/test/e2e/explicit-capture.e2e.test.ts
@@ -1,0 +1,148 @@
+import axios from 'axios';
+import fetch from 'node-fetch';
+
+import Supergood from '../../src';
+import { LocalClientId, LocalClientSecret, errors } from '../../src/constants';
+
+import { sleep } from '../../src/utils';
+import {
+  BASE64_REGEX,
+  MOCK_DATA_SERVER,
+  SUPERGOOD_CLIENT_ID,
+  SUPERGOOD_CLIENT_SECRET,
+  SUPERGOOD_CONFIG,
+  SUPERGOOD_SERVER
+} from '../consts';
+import { mockApi } from '../utils/mock-api';
+import { checkPostedEvents } from '../utils/function-call-args';
+
+describe('capture functionality', () => {
+  const { postEventsMock, postErrorMock } = mockApi();
+
+  describe('withCapture success states', () => {
+    it('should ONLY capture all outgoing 200 http requests wrapped in withCapture', async () => {
+      const numberOfHttpCalls = 5;
+      await axios.get(`${MOCK_DATA_SERVER}/posts`);
+      await Supergood.withCapture(
+        {
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          baseUrl: SUPERGOOD_SERVER
+        },
+      async () => {
+        for (let i = 0; i < numberOfHttpCalls; i++) {
+          await axios.get(`${MOCK_DATA_SERVER}/posts`);
+        }
+      })
+      await axios.get(`${MOCK_DATA_SERVER}/posts`);
+      checkPostedEvents(postEventsMock, numberOfHttpCalls, {
+        request: expect.objectContaining({
+          requestedAt: expect.any(Date)
+        }),
+        response: expect.objectContaining({
+          respondedAt: expect.any(Date)
+        })
+      });
+    });
+
+    it('should ONLY capture all outgoing 200 http requests wrapped in withCapture, despite other threads also being logged', async () => {
+      const numberOfHttpCalls = 5;
+
+      const getInterval = setInterval(async () => {
+        await axios.get(`${MOCK_DATA_SERVER}/posts`), 250
+      });
+
+      await Supergood.withCapture(
+        {
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          baseUrl: SUPERGOOD_SERVER
+        },
+      async () => {
+        for (let i = 0; i < numberOfHttpCalls; i++) {
+          await axios.get(`${MOCK_DATA_SERVER}/posts`);
+        }
+      })
+
+      getInterval.unref();
+
+      checkPostedEvents(postEventsMock, numberOfHttpCalls, {
+        request: expect.objectContaining({
+          requestedAt: expect.any(Date)
+        }),
+        response: expect.objectContaining({
+          respondedAt: expect.any(Date)
+        })
+      });
+    });
+  });
+
+  describe('startCapture success states', () => {
+    it('should ONLY capture all outgoing 200 http requests after startCapture and before stopCapture', async () => {
+      const numberOfHttpCalls = 5;
+      await axios.get(`${MOCK_DATA_SERVER}/posts`);
+
+      await Supergood.startCapture(
+        {
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          baseUrl: SUPERGOOD_SERVER
+        });
+
+      for (let i = 0; i < numberOfHttpCalls; i++) {
+        await axios.get(`${MOCK_DATA_SERVER}/posts`);
+      }
+
+      await Supergood.stopCapture();
+      await axios.get(`${MOCK_DATA_SERVER}/posts`);
+
+      checkPostedEvents(postEventsMock, numberOfHttpCalls, {
+        request: expect.objectContaining({
+          requestedAt: expect.any(Date)
+        }),
+        response: expect.objectContaining({
+          respondedAt: expect.any(Date)
+        })
+      });
+    });
+
+    it('should ONLY capture all outgoing 200 http requests after startCapture and before stopCapture, despite other threads also being logged', async () => {
+      const numberOfHttpCalls = 5;
+
+      const getInterval = setInterval(async () => {
+        await axios.get(`${MOCK_DATA_SERVER}/posts`), 250
+      });
+
+      await Supergood.startCapture(
+        {
+          config: { ...SUPERGOOD_CONFIG, allowLocalUrls: true },
+          clientId: SUPERGOOD_CLIENT_ID,
+          clientSecret: SUPERGOOD_CLIENT_SECRET,
+          baseUrl: SUPERGOOD_SERVER
+        });
+
+
+      for (let i = 0; i < numberOfHttpCalls; i++) {
+        await axios.get(`${MOCK_DATA_SERVER}/posts`);
+      }
+
+      await Supergood.stopCapture();
+
+      getInterval.unref();
+
+      checkPostedEvents(postEventsMock, numberOfHttpCalls, {
+        request: expect.objectContaining({
+          requestedAt: expect.any(Date)
+        }),
+        response: expect.objectContaining({
+          respondedAt: expect.any(Date)
+        })
+      });
+    });
+  });
+
+
+});


### PR DESCRIPTION
- Adds three functions to enable more fine grained logging
- Capture functions do not require await, if `useRemoteConfig` is set to false
- Capture functions do not flush automatically, flush still needs to happen explicitly or on an interval
- Fixes issue with AllowedDomains not being passed in to native http.get and http.request calls.

New Functions:

`Supergood.withCapture` allows only async functions within the context to be logged with Supergood.

Usage:

```
await asyncCall0();

const asyncCall3Result = await Supergood.withCapture(supergoodArgs, async () => {
  await asyncCall1();
  await asyncCall2();
  return asyncCall3();
});
await Supergood.close();

await asyncCall4();
```

Only asyncCalls 1 - 3 will be logged with Supergood, and 0 & 4 will be ignored.

`Supergood.startCapture` and `Supergood.stopCapture` will perform the same functionality as above, but without the wrapped context.

Usage:

```
await asyncCall0();

Supergood.startCapture(supergoodArgs);

await asyncCall1();
await asyncCall2();
await asyncCall3();

Supergood.stopCapture();

await asyncCall4();

await Supergood.close();
```

Similar to the previous above, only asyncCalls 1 - 3 will be logged with Supergood, and 0 & 4 will be ignored.

